### PR TITLE
Fix missing mDNS dependency

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -9,6 +9,7 @@ issues: "https://github.com/AchimPieters/ESP32-captive_portal/issues"
 license: "MIT"
 dependencies:
   idf: ">=5.0"
+  espressif/mdns: "*"
 targets:
   - "esp32"
   - "esp32c2"


### PR DESCRIPTION
## Summary
- declare explicit dependency on `espressif/mdns` so the captive portal can compile on IDF v5

## Testing
- `idf.py build` *(fails: Failed to resolve component 'mdns')*

------
https://chatgpt.com/codex/tasks/task_e_6873d2d81760832193271bfc275d699d