### PR TITLE
Fix CMakeLists for component use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(wifi_captive_portal)
+
+# When this repository is used as an ESP-IDF component the CMake file is
+# executed in script mode. Including the project build system in this case
+# results in an error ("define_property command is not scriptable").  Only
+# include the ESP-IDF project infrastructure when this file is processed as the
+# top level project.
+if(NOT CMAKE_SCRIPT_MODE_FILE)
+    include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+    project(wifi_captive_portal)
+endif()


### PR DESCRIPTION
## Summary
- avoid running project build logic when the repository is used as a managed component

## Testing
- `idf.py set-target esp32` *(fails to resolve `mdns` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6874b585e9e483218b2ea6b0fdc41fbd