### PR TITLE
Update docs for ESP-IDF 5.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ESP32-captive_portal
 ESP-IDF Captive Portal & WiFi Provisioning Component
 
+This project requires **ESP-IDF v5.2.4 or newer** to build.
+
 ## What it Does
 
 This component provides a complete captive portal with WiFi setup (including WiFi scanning!), DNS hijack, HTTP server, and mDNS (.local) for any ESP32 project.  

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,7 +8,7 @@ repository: "https://github.com/AchimPieters/ESP32-captive_portal"
 issues: "https://github.com/AchimPieters/ESP32-captive_portal/issues"
 license: "MIT"
 dependencies:
-  idf: ">=5.0"
+  idf: ">=5.2.4"
   espressif/mdns: "*"
 targets:
   - "esp32"


### PR DESCRIPTION
## Summary
- note ESP-IDF v5.2.4 requirement
- bump required IDF version in component metadata

## Testing
- `idf.py --version` *(fails: /root/.espressif/espidf.constraints.v5.2.txt doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6874d10baca083219038436b3c7f4379