### PR TITLE
Use index.html as generated header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(DEFINED WIFI_CONFIG_INDEX_HTML)
 else()
     set(html_file "${CMAKE_CURRENT_SOURCE_DIR}/content/index.html")
 endif()
-set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/index.html.h)
+set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/index.html)
 add_custom_command(OUTPUT ${generated_file}
     COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tools/embed.py ${html_file} > ${generated_file}
     DEPENDS ${html_file}

--- a/dist/esp32-captive_portal_1.0.0/CMakeLists.txt
+++ b/dist/esp32-captive_portal_1.0.0/CMakeLists.txt
@@ -10,7 +10,7 @@ if(DEFINED WIFI_CONFIG_INDEX_HTML)
 else()
     set(html_file "${CMAKE_CURRENT_SOURCE_DIR}/content/index.html")
 endif()
-set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/index.html.h)
+set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/index.html)
 add_custom_command(OUTPUT ${generated_file}
     COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tools/embed.py ${html_file} > ${generated_file}
     DEPENDS ${html_file}

--- a/dist/esp32-captive_portal_1.0.0/src/wifi_config.c
+++ b/dist/esp32-captive_portal_1.0.0/src/wifi_config.c
@@ -246,7 +246,7 @@ static void wifi_scan_task(void *arg)
     vTaskDelete(NULL);
 }
 
-#include "index.html.h"
+#include "index.html"
 
 static void wifi_config_server_on_settings(client_t *client) {
     static const char http_prologue[] =

--- a/dist/esp32-captive_portal_2.0.0/CMakeLists.txt
+++ b/dist/esp32-captive_portal_2.0.0/CMakeLists.txt
@@ -10,7 +10,7 @@ if(DEFINED WIFI_CONFIG_INDEX_HTML)
 else()
     set(html_file "${CMAKE_CURRENT_SOURCE_DIR}/content/index.html")
 endif()
-set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/index.html.h)
+set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/index.html)
 add_custom_command(OUTPUT ${generated_file}
     COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tools/embed.py ${html_file} > ${generated_file}
     DEPENDS ${html_file}

--- a/dist/esp32-captive_portal_2.0.0/src/wifi_config.c
+++ b/dist/esp32-captive_portal_2.0.0/src/wifi_config.c
@@ -246,7 +246,7 @@ static void wifi_scan_task(void *arg)
     vTaskDelete(NULL);
 }
 
-#include "index.html.h"
+#include "index.html"
 
 static void wifi_config_server_on_settings(client_t *client) {
     static const char http_prologue[] =

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -249,7 +249,7 @@ static void wifi_scan_task(void *arg)
         vTaskDelete(NULL);
 }
 
-#include "index.html.h"
+#include "index.html"
 
 static void wifi_config_server_on_settings(client_t *client) {
         static const char http_prologue[] =


### PR DESCRIPTION
## Summary
- adjust project CMake files to generate an `index.html` header instead of `index.html.h`
- update `wifi_config.c` references accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `idf.py build` *(fails: Unknown CMake command `idf_component_register`)*

------
https://chatgpt.com/codex/tasks/task_e_6878ba1f85388321bc593ac2ea5329be