### PR TITLE
Embed index.html directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,9 @@
 idf_component_register(SRCS "src/wifi_config.c" "src/form_urlencoded.c"
                     INCLUDE_DIRS "include" "src"
-                    PRIV_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}"
                     REQUIRES esp_wifi esp_event esp_netif nvs_flash http_parser esp_timer
-)
+                    EMBED_TXTFILES "content/index.html")
 
-# Allow projects to override the default HTML page
-if(DEFINED WIFI_CONFIG_INDEX_HTML)
-    set(html_file "${WIFI_CONFIG_INDEX_HTML}")
-else()
-    set(html_file "${CMAKE_CURRENT_SOURCE_DIR}/content/index.html")
-endif()
-set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/index.html)
-add_custom_command(OUTPUT ${generated_file}
-    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tools/embed.py ${html_file} > ${generated_file}
-    DEPENDS ${html_file}
-    VERBATIM)
 
-add_custom_target(generate_html DEPENDS ${generated_file})
-add_dependencies(${COMPONENT_LIB} generate_html)
-
-target_include_directories(${COMPONENT_LIB} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # Propagate optional configuration flags for backwards compatibility
 if(WIFI_CONFIG_DEBUG)


### PR DESCRIPTION
## Summary
- embed `content/index.html` as a text file in the component
- remove generated header usage and send the full HTML file in the settings handler

## Testing
- `idf.py reconfigure` *(fails: unknown `idf_component_register` since this repo isn't a full ESP‑IDF project)*

------
https://chatgpt.com/codex/tasks/task_e_6878be83b160832187f1e7d837aa6cb3