### PR TITLE
Fix SoftAP SSID length

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,9 @@ WIFI_CONFIG_INDEX_HTML before your run tools/server.py:
 
     export WIFI_CONFIG_INDEX_HTML=my_wifi_config.html
     path/to/your/wifi-config/tools/server.py
+
+## SoftAP SSID length
+
+The automatically generated SoftAP SSID is limited to 32 characters. Ensure that
+`wifi_config_init()` or `wifi_config_init2()` is called with an `ssid_prefix`
+short enough so that the full SSID fits within this limit.

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -675,10 +675,11 @@ static void wifi_config_softap_start() {
         wifi_config_t ap_config;
         memset(&ap_config, 0, sizeof(ap_config));
         ap_config.ap.channel = 6;
-        ap_config.ap.ssid_len = snprintf(
+        snprintf(
                 (char *)ap_config.ap.ssid, sizeof(ap_config.ap.ssid),
-                "%s-%02X%02X%02X", context->ssid_prefix, macaddr[3], macaddr[4], macaddr[5]
-                );
+                "%s-%02X%02X%02X", context->ssid_prefix,
+                macaddr[3], macaddr[4], macaddr[5]);
+        ap_config.ap.ssid_len = strlen((char *)ap_config.ap.ssid);
         ap_config.ap.ssid_hidden = 0;
         if (context->password) {
                 ap_config.ap.authmode = WIFI_AUTH_WPA_WPA2_PSK;


### PR DESCRIPTION
## Summary
- ensure SoftAP SSID length does not exceed 32 characters
- document SSID prefix length requirements in README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e94082a883219cf3eef580ddf7e8