### PR TITLE
Improve captive portal detection on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,5 @@ short enough so that the full SSID fits within this limit.
 The DHCP server now advertises the device as the DNS server (192.168.4.1) to
 connected clients. This improves automatic captive portal detection on iOS and
 macOS devices.
+
+On macOS Sequoia systems the automatic popup might not appear immediately. If this happens, open http://192.168.4.1 in your browser to access the configuration portal.

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -316,15 +316,15 @@ static int wifi_config_server_on_url(http_parser *parser, const char *data, size
 
         client->endpoint = ENDPOINT_UNKNOWN;
         if (parser->method == HTTP_GET) {
-                if (!strncmp(data, "/settings", length)) {
+                if (!strncmp(data, "/settings", strlen("/settings"))) {
                         client->endpoint = ENDPOINT_SETTINGS;
-                } else if (!strncmp(data, "/hotspot-detect.html", length)) {
+                } else if (!strncmp(data, "/hotspot-detect.html", strlen("/hotspot-detect.html"))) {
                         client->endpoint = ENDPOINT_CAPTIVE_DETECT;
-                } else if (!strncmp(data, "/library/test/success.html", length)) {
+                } else if (!strncmp(data, "/library/test/success.html", strlen("/library/test/success.html"))) {
                         client->endpoint = ENDPOINT_CAPTIVE_DETECT;
-                } else if (!strncmp(data, "/generate_204", length)) {
+                } else if (!strncmp(data, "/generate_204", strlen("/generate_204"))) {
                         client->endpoint = ENDPOINT_CAPTIVE_DETECT;
-                } else if (!strncmp(data, "/", length)) {
+                } else if (!strncmp(data, "/", strlen("/"))) {
                         client->endpoint = ENDPOINT_INDEX;
                 }
         } else if (parser->method == HTTP_POST) {


### PR DESCRIPTION
## Summary
- fix the endpoint matching to ignore query parameters
- document a workaround for macOS Sequoia

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command `idf_component_register`)*

------
https://chatgpt.com/codex/tasks/task_e_6878f1f28fcc8321a9718b743a150642