### PR TITLE
Serve index.html for captive portal detection

### DIFF
--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -385,8 +385,8 @@ static int wifi_config_server_on_message_complete(http_parser *parser) {
                 break;
         }
         case ENDPOINT_CAPTIVE_DETECT: {
-                DEBUG("GET captive portal detection");
-                client_send_redirect(client, 302, "http://192.168.4.1/settings");
+                DEBUG("GET captive portal detection -> serving index.html");
+                wifi_config_server_on_settings(client);
                 break;
         }
         case ENDPOINT_UNKNOWN: {


### PR DESCRIPTION
## Summary
- when clients hit hotspot-detect.html or related URLs, serve the WiFi config index page instead of redirecting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a46c949108321b3b2c325684eca64