### PR TITLE
Handle missing index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ accessories' WiFi configuration. The component has been fully
 updated for the ESP-IDF 5.4 API and requires this version of the
 framework.
 
+If the captive portal page appears blank, the HTML template was not
+embedded into the firmware. Build the project with ESP-IDF **5.4 or
+later** so CMake can embed `content/index.html` automatically.
+
 Library uses NVS to store configuration. When you initialize it, the library
 tries to connect to the configured WiFi network. If no configuration exists or
 the network is not available, it starts its own WiFi AP (with the given name and

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -277,6 +277,16 @@ static void wifi_config_server_on_settings(client_t *client) {
                 "Connection: close\r\n\r\n";
 
         client_send(client, http_prologue, sizeof(http_prologue) - 1);
+
+        if (html_len == 0) {
+                static const char error_page[] =
+                        "<html><body><h1>Missing index.html</h1>"
+                        "<p>The captive portal page was not embedded. "
+                        "Build with ESP-IDF 5.4 or later."</p></body></html>";
+                client_send(client, error_page, sizeof(error_page) - 1);
+                return;
+        }
+
         client_send(client, (const char *)index_html_start, html_len);
 }
 


### PR DESCRIPTION
## Summary
- show a helpful message if index.html wasn't embedded
- clarify README about requiring ESP-IDF 5.4 to embed the HTML

## Testing
- `idf.py build` *(fails: Unknown CMake command "idf_component_register" because this repo is just a component)*

------
https://chatgpt.com/codex/tasks/task_e_687a6e8b8cac83219afd88551fbf6841